### PR TITLE
Errors entering admin/admin_synchronization.php

### DIFF
--- a/class/read.php
+++ b/class/read.php
@@ -345,6 +345,15 @@ class NewbbReadHandler extends XoopsPersistableObjectHandler
      */
     public function clearDuplicate()
     {
+        /**
+         * This is needed for the following query GROUP BY clauses to work in MySQL 5.7.
+         * This is a TEMPORARY fix. Needing this function is bad in the first place, but
+         * needing sloppy SQL to make it work is worse.
+         * @todo The schema itself should preclude the duplicates
+         */
+        $sql = "SET sql_mode=(SELECT REPLACE(@@sql_mode, 'ONLY_FULL_GROUP_BY', ''))";
+        $this->db->queryF($sql);
+
         $sql = 'CREATE TABLE ' . $this->table . '_duplicate LIKE ' . $this->table . '; ';
         if (!$result = $this->db->queryF($sql)) {
             xoops_error($this->db->error() . '<br>' . $sql);

--- a/class/stats.php
+++ b/class/stats.php
@@ -201,6 +201,7 @@ class NewbbStatsHandler
                 $sql    = '    SELECT COUNT(*), SUM(topic_views)' . '    FROM ' . $this->db->prefix('newbb_topics') . "    WHERE approved=1 AND forum_id = {$forum_id}" . "        AND FROM_UNIXTIME(topic_time, '{$format}') >= FROM_UNIXTIME({$now}, '{$format}')";
                 $result = $this->db->query($sql);
                 list($topics, $views) = $this->db->fetchRow($result);
+                $views = empty($views) ? 0 : $views; // null check
                 $this->db->queryF("    INSERT INTO {$this->table}"
                                   . '        (`stats_id`, `stats_value`, `stats_type`, `stats_period`, `time_update`, `time_format`) '
                                   . '    VALUES '


### PR DESCRIPTION
Using MySQL 5.7.19, see the following errors when entering admin_syncronization.php

Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'x258i.x569_newbb_reads_topic.read_id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by

INSERT x569_newbb_reads_topic_duplicate SELECT * FROM x569_newbb_reads_topic GROUP BY read_item, uid;

Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'x258i.x569_newbb_reads_forum.read_id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by

INSERT x569_newbb_reads_forum_duplicate SELECT * FROM x569_newbb_reads_forum GROUP BY read_item, uid;

Also
INSERT INTO newbb_stats (`stats_id`, `stats_value`, `stats_type`, `stats_period`, `time_update`, `time_format`) VALUES ('1', '', '3', '1', NOW(), '%Y%j')
Error number: 1366
Error message: Incorrect integer value: '' for column 'stats_value' at row 1

*More work/testing is needed, but this patch allows the program to start cleanly on entry.*
